### PR TITLE
Add check for Key Degradation Attack

### DIFF
--- a/src/spake2/spake2.py
+++ b/src/spake2/spake2.py
@@ -25,6 +25,8 @@ class WrongGroupError(SPAKEError):
     pass
 class ReflectionThwarted(SPAKEError):
     """Someone tried to reflect our message back to us."""
+class KeyDegradationThwarted(SPAKEError):
+    """Someone tried to degrade our key material."""
 
 SideA = b"A"
 SideB = b"B"
@@ -113,6 +115,8 @@ class _SPAKE2_Base:
         #          ) * self.xy_scalar
         pw_unblinding = self.my_unblinding().scalarmult(-self.pw_scalar)
         K_elem = inbound_elem.add(pw_unblinding).scalarmult(self.xy_scalar)
+        if K_elem is g.Zero:
+            raise KeyDegradationThwarted
         K_bytes = K_elem.to_bytes()
         key = self._finalize(K_bytes)
         return key


### PR DESCRIPTION
Found out, that the SPAKE2-implementation is missing an important check for key degradation, where an attacker is able to degrade the keys to identitiy (zero element), when he gets to know the password. (see https://moderncrypto.org/mail-archive/curves/2015/000427.html)
This is critical, because, it would destroy PFS on the channel, and makes MiM much more easier.

@TODO: just added a small check for zero element, but had no time to really test it.
@TODO: didn't check the relevance for SPAKE2+

Regards, Mike